### PR TITLE
Use unique fields when needed

### DIFF
--- a/src/data/migrations/20240206141500_ingredients_and_recipes_tables.ts
+++ b/src/data/migrations/20240206141500_ingredients_and_recipes_tables.ts
@@ -5,6 +5,7 @@ export async function up(knex: Knex) {
     .createTable('ingredients', (table) => {
       table.bigIncrements('id', { primaryKey: true }).unsigned();
       table.string('name', 100).notNullable();
+      table.unique('name');
     })
     .createTable('recipes', (table) => {
       table.bigIncrements('id', { primaryKey: true }).unsigned();
@@ -24,6 +25,7 @@ export async function up(knex: Knex) {
         .onDelete('cascade');
       table.tinyint('ranking').unsigned().notNullable();
       table.text('text').notNullable();
+      table.unique(['recipe_id', 'ranking']);
     })
     .createTable('recipes_ingredients', (table) => {
       table.bigIncrements('id', { primaryKey: true }).unsigned();
@@ -45,6 +47,7 @@ export async function up(knex: Knex) {
         .inTable('ingredients')
         .onDelete('set null');
       table.string('quantity').notNullable();
+      table.unique(['recipe_id', 'ingredient_id']);
     });
 }
 

--- a/src/data/migrations/20240214100900_shops_staff_shop_stocks.ts
+++ b/src/data/migrations/20240214100900_shops_staff_shop_stocks.ts
@@ -16,6 +16,7 @@ export async function up(knex: Knex) {
       table.string('email', 255).notNullable();
       table.dateTime('created_at').notNullable().defaultTo(knex.raw('NOW()'));
       table.dateTime('updated_at').notNullable().defaultTo(knex.raw('NOW()'));
+      table.unique('email');
     })
     .createTable('stocks', (table) => {
       table.bigIncrements('id', { primaryKey: true }).unsigned();
@@ -35,11 +36,11 @@ export async function up(knex: Knex) {
         .references('id')
         .inTable('ingredients')
         .onDelete('cascade');
-      table.unique(['shop_id', 'ingredient_id']);
       table.integer('quantity').notNullable();
       table.integer('unit_price').notNullable();
       table.dateTime('created_at').notNullable().defaultTo(knex.raw('NOW()'));
       table.dateTime('updated_at').notNullable().defaultTo(knex.raw('NOW()'));
+      table.unique(['shop_id', 'ingredient_id']);
     });
 
   await knex.schema.createTable('shops_staffs', (table) => {
@@ -60,6 +61,7 @@ export async function up(knex: Knex) {
       .references('id')
       .inTable('staffs')
       .onDelete('cascade');
+    table.unique(['shop_id', 'staff_id']);
   });
 }
 


### PR DESCRIPTION
Fixes #9 

I decided not to implement a check in the `StaffRepository.create` method. The unique constraint in db makes us sure that we do not have duplicates, meanwhile the general case should be handle inside the controller.

Found several missing unique constraints, added those.